### PR TITLE
Expose Paperspace machines as Garage Door openers

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "displayName": "Paperspace Plugin for Homebridge",
   "name": "homebridge-paperspace",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Connect your Paperspace account to Homebridge",
   "license": "ISC",
   "repository": {


### PR DESCRIPTION
Garage Door openers can accurately reflect starting/stopping states of Paperspace machines as "Opening" and "Closing" of the garage door.
They also require authentication to open, which can prevent being billed for a machine started accidentally.